### PR TITLE
Remove the usage of BinaryFormatter

### DIFF
--- a/src/Aldsoft.Acord/EntityBase.cs
+++ b/src/Aldsoft.Acord/EntityBase.cs
@@ -207,14 +207,8 @@
                 throw new ArgumentException("The type must be serializable.", "source");
             }
 
-            IFormatter formatter = new BinaryFormatter();
-            Stream stream = new MemoryStream();
-            using (stream)
-            {
-                formatter.Serialize(stream, this);
-                stream.Seek(0, SeekOrigin.Begin);
-                return (T)formatter.Deserialize(stream);
-            }
+            Serialize(out string xml);
+            return Deserialize(xml);
         }
     }
 }


### PR DESCRIPTION
[BinaryFormatter is deprecated](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatters.binary.binaryformatter?view=net-8.0)

To use this library `BinaryFormatter` has to be explicitly reanabled by adding `<EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>` to .csproj files, which is not recommended by Microsoft. From what I see, `BinaryFormatter` is used only to perform a deep copy, so if we can use something else, users of the library won't have to add that potentially dangerous setting.

I run the unit tests and all of them passed.